### PR TITLE
Support node-sass@3.x

### DIFF
--- a/lasso-sass-plugin.js
+++ b/lasso-sass-plugin.js
@@ -40,7 +40,13 @@ module.exports = function(lasso, config) {
 
                 renderOptions.file = path;
 
-                sass.render(renderOptions, callback);
+                sass.render(renderOptions, function(error, result) {
+                    if (error) {
+                        callback(error);
+                    } else {
+                        callback(null, result.css);
+                    }
+                });
             },
 
             getSourceFile: function() {

--- a/lasso-sass-plugin.js
+++ b/lasso-sass-plugin.js
@@ -40,15 +40,7 @@ module.exports = function(lasso, config) {
 
                 renderOptions.file = path;
 
-                renderOptions.success = function(css) {
-                    callback(null, css);
-                };
-
-                renderOptions.error = function(err) {
-                    callback(err);
-                };
-
-                sass.render(renderOptions);
+                sass.render(renderOptions, callback);
             },
 
             getSourceFile: function() {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     ],
     "maintainers": "Patrick Steele-Idem <pnidem@gmail.com>",
     "dependencies": {
-        "node-sass": "^0.9.3",
+        "node-sass": ">=0.9.3",
         "raptor-logging": "^1.0.1",
         "raptor-util": "^1.0.0"
     },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     ],
     "maintainers": "Patrick Steele-Idem <pnidem@gmail.com>",
     "dependencies": {
-        "node-sass": ">=0.9.3",
+        "node-sass": "^3.3.0",
         "raptor-logging": "^1.0.1",
         "raptor-util": "^1.0.0"
     },


### PR DESCRIPTION
These changes bring the node-sass dependency up to date. Consider relaxing the requirement to ^3.0.0 as that is when the breaking API change occurred. It also might make sense to bump the `lasso-sass` version to 3.0 to mirror the `node-sass` version. 
