### PR TITLE
Fixing Test: Image Path

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -156,7 +156,7 @@ describe('lasso-sass' , function() {
                 }
 
                 var output = fs.readFileSync(nodePath.join(__dirname, 'static/testPage.css'), {encoding: 'utf8'});
-                expect(output).to.equal(".test {\n  background-image: url(test.png); }\n");
+                expect(output).to.equal(".test {\n  background-image: url('test.png'); }\n");
                 done();
             });
     });


### PR DESCRIPTION
The image path test was failing due to missing quotes, this adds them to the expected output.