### PR TITLE
Fix broken build. Use ES5 in tests.

### DIFF
--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -15,7 +15,7 @@
         "runs"
     ],
     "node" : true,
-    "esnext": true,
+    "esnext": false,
     "browser" : true,
     "boss" : false,
     "curly": false,

--- a/test/autotest.js
+++ b/test/autotest.js
@@ -11,7 +11,7 @@ var enabledTests = null;
 if (enabledTestNames && enabledTestNames.length > 1) {
     enabledTests = {};
     enabledTest = null;
-    enabledTestNames.forEach((testName) => {
+    enabledTestNames.forEach(function (testName) {
         enabledTests[testName] = true;
     });
 }
@@ -51,7 +51,7 @@ function autoTest(name, dir, run, options, done) {
     options = options || {};
 
     var helpers = {
-        compare(actual, suffix) {
+        compare: function (actual, suffix) {
             compareHelper(dir, actual, suffix);
         }
     };
@@ -79,7 +79,7 @@ exports.scanDir = function(autoTestDir, run, options) {
 
                 var dir = path.join(autoTestDir, name);
 
-                itFunc(`[${name}] `, function(done) {
+                itFunc('[' + name + '] ', function(done) {
                     autoTest(name, dir, run, options, done);
                 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -46,18 +46,15 @@ describe('lasso-sass/plugin' , function() {
             rmdirRecursive(lassoConfig.outputDir);
 
             var myLasso = lasso.create(lassoConfig, dir);
-
             var inputs;
 
-            let lassoOptions = (main.getLassoOptions && main.getLassoOptions(dir)) || {};
-
-
-            let check = main.check;
+            var lassoOptions = (main.getLassoOptions && main.getLassoOptions(dir)) || {};
+            var check = main.check;
 
             inputs = [
                 {
-                    lassoOptions,
-                    check
+                    lassoOptions: lassoOptions,
+                    check: check
                 }
             ];
 
@@ -72,7 +69,7 @@ describe('lasso-sass/plugin' , function() {
             }
 
             myLasso.lassoPage(lassoOptions)
-                .then((lassoPageResult) => {
+                .then(function (lassoPageResult) {
                     if (checkError) {
                         return done('Error expected');
                     }
@@ -93,7 +90,7 @@ describe('lasso-sass/plugin' , function() {
 
                     lasso.flushAllCaches(done);
                 })
-                .catch((err) => {
+                .catch(function (err) {
                     if (checkError) {
                         checkError(err);
                         done();


### PR DESCRIPTION
Commit https://github.com/lasso-js/lasso-sass/commit/0a00c432ee76fb437962fdd096a883b1a6dd1b1b is causing the build to fail because ES6 syntax was introduced into the test code. `node-sass` supports Node 0.10, which is the lowest version that our build runs on. We could safely allow our users to upgrade and gain all the benefits of the latest node-sass. Original request: https://github.com/lasso-js/lasso-sass/issues/1. With that being said, I'm also okay with just removing the old versions of Node from travis. What do you think @patrick-steele-idem @mlrawlings?